### PR TITLE
Login and create user methods not returning expected FirebaseUser types.

### DIFF
--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -46,7 +46,7 @@ class AuthService with ChangeNotifier {
           .signInWithEmailAndPassword(email: email, password: password);
       // since something changed, let's notify the listeners...
       notifyListeners();
-      return result;
+      return result.user;
     }  catch (e) {
       throw new AuthException(e.code, e.message);
     }

--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -26,9 +26,10 @@ class AuthService with ChangeNotifier {
       String lastName,
       String email,
       String password}) async {
-    var u = await FirebaseAuth.instance
+    var r = await FirebaseAuth.instance
         .createUserWithEmailAndPassword(email: email, password: password);
 
+    var u = r.user;
     UserUpdateInfo info = UserUpdateInfo();
     info.displayName = '$firstName $lastName';
     return await u.updateProfile(info);


### PR DESCRIPTION
I've been using this guide to help learn to wrap my app with Firebase Auth using provider (and it's the most straight-forward I've found, so thanks a lot for writing it).

I immediately experienced type errors as AuthResult objects were being returned where FirebaseUser objects were expected. The Firebase Auth documentation says to use the getUser() method on an AuthResult object but after receiving errors trying that I inspected the actual AuthResult class in the firebase_auth package and it's found at AuthResult.user.

I've changed the AuthResult to `r` and assigned `u` from `r.user` in createUser() and changed loginUser() to return `result.user` instead of `result`.

These changes have been minimally tested as this is a learning project but after my changes I am able to run the app, log in to a test user created in the Firebase console, and log out.